### PR TITLE
A few fixes to work with version 2.29 of Vale on Linux

### DIFF
--- a/Openly/Link.yml
+++ b/Openly/Link.yml
@@ -1,8 +1,8 @@
 ---
-message: "Don't use '%s' as the content of a link."
+message: "Don't use 'here' as the content of a link."
 extends: existence
 ignorecase: true
-scope: link
+scope: raw
 level: error
-tokens:
-  - here
+raw:
+  - '\[here\]\(.+\)'

--- a/Openly/Spelling.yml
+++ b/Openly/Spelling.yml
@@ -4,18 +4,17 @@ message: "Did you really mean '%s'?"
 level: error
 code: false
 ignore:
-  - openly/tech-terms/security.txt
-  - openly/tech-terms/blockchain.txt
-  - openly/tech-terms/devops.txt
-  - openly/tech-terms/general.txt
-  - openly/tech-terms/techwriting.txt
-  - openly/tech-terms/mobile.txt
-  - openly/tech-terms/java.txt
-  - openly/tech-terms/linux.txt
-  - openly/tech-terms/tech-slang.txt
-  - openly/tech-terms/csharp.txt
-  - openly/tech-terms/ddd.txt
-  - openly/tech-terms/business.txt
-  - openly/tech-terms/monitoring.txt
-  - openly/tech-terms/apis.txt
-  - openly/tech-terms/geospatial.txt
+  - Openly/tech-terms/security.txt
+  - Openly/tech-terms/blockchain.txt
+  - Openly/tech-terms/devops.txt
+  - Openly/tech-terms/general.txt
+  - Openly/tech-terms/techwriting.txt
+  - Openly/tech-terms/mobile.txt
+  - Openly/tech-terms/java.txt
+  - Openly/tech-terms/linux.txt
+  - Openly/tech-terms/tech-slang.txt
+  - Openly/tech-terms/csharp.txt
+  - Openly/tech-terms/ddd.txt
+  - Openly/tech-terms/business.txt
+  - Openly/tech-terms/monitoring.txt
+  - Openly/tech-terms/apis.txt


### PR DESCRIPTION
- `link` scope is no longer supported so `raw` must be used with a regex
- Capitalization of 'Openly' directory must match for installation to work out of the box